### PR TITLE
Bug: addButtonWithTitle fails when 0 buttons passed in initWithTitle

### DIFF
--- a/TTAlertView/TTAlertView.m
+++ b/TTAlertView/TTAlertView.m
@@ -269,6 +269,7 @@ static CGFloat const kTTDefaultDialogButtonHeight = 44.0f;
     [otherButton addTarget:self action:@selector(otherButtonAction:) forControlEvents:UIControlEventTouchUpInside];
     [otherButton setTitle:title forState:UIControlStateNormal];
     [self.containerView addSubview:otherButton];
+    if (self.firstOtherButtonIndex < 0) _firstOtherButtonIndex = MAX(_cancelButtonIndex, 0) + 1;
     [self.buttons insertObject:otherButton atIndex:([self.buttons count] - 1) + self.firstOtherButtonIndex];
     
     if(self.isVisible) {


### PR DESCRIPTION
If you use `addButtonWithTitle` to add additional buttons rather than pass them all through `initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles` then the indexing of the buttons is incorrect. Maybe `addButtonWithTitle` wasn't designed to be a public method used this way, but I've found it's helpful sometimes to iteratively add buttons.

eg.

```
TTAlertView *alert = [[TTAlertView alloc] initWithTitle:@"test" message:@"testing alert" delegate:nil cancelButtonTitle:@"cancel" otherButtonTitles:nil];

...

[alert addButtonWithTitle:@"button that should show"];
[alert show];

```
